### PR TITLE
chore: move header contents of staking into a component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,13 +5,7 @@ import {
   Switch,
   Redirect,
 } from "react-router-dom";
-import {
-  Center,
-  ChakraProvider,
-  extendTheme,
-  Flex,
-  Text,
-} from "@chakra-ui/react";
+import { ChakraProvider, extendTheme } from "@chakra-ui/react";
 import { ThemeProvider } from "styled-components";
 import { Layout } from "./layout";
 import Markets from "./views/Markets";
@@ -30,6 +24,7 @@ import WithdrawConfirm from "./views/Withdraw/WithdrawConfirm";
 // import Collateral from './views/Collateral';
 // import InterestSwap from './views/InterestSwap';
 import { Staking } from "./views/Staking";
+import { StakingBanner } from "./views/Staking/layout";
 import "react-notifications-component/dist/theme.css";
 import "./App.css";
 //import "animate.css/animate.min.css";
@@ -76,24 +71,7 @@ const App: React.FC<IAppProps> = props => {
               // prettier-ignore
               <Switch>
                 <Route path="/stake">
-                  <Flex px="4.7rem" basis="100%" justifyContent="space-between">
-                    <Text fontWeight="bold" color="white" fontSize="2.4rem">
-                      Staking
-                    </Text>
-                    <Center>
-                      <Text color="white" fontSize="1.6rem" mr="1.2rem">
-                        Funds in the Safety Module
-                      </Text>
-                      <Text
-                        fontSize="2.4rem"
-                        fontWeight="bold"
-                        bg="linear-gradient(90.53deg, #9BEFD7 0%, #8BF7AB 47.4%, #FFD465 100%);"
-                        backgroundClip="text"
-                      >
-                        $ {TOTAL_VALUE_LOCKED}
-                      </Text>
-                    </Center>
-                  </Flex>
+                  <StakingBanner tvl={TOTAL_VALUE_LOCKED} />
                 </Route>
                 <Route path="/markets">Welcome!</Route>
               </Switch>

--- a/src/components/Actions/WeiBox.tsx
+++ b/src/components/Actions/WeiBox.tsx
@@ -2,21 +2,17 @@ import { BigNumberish, parseFixed } from "@ethersproject/bignumber";
 import { BigNumber, FixedNumber } from "ethers";
 import React, { ReactNode, useEffect, useMemo, useState } from "react";
 import {
-  Box,
   Button,
-  Center,
   HStack,
   Image,
   Input,
   InputGroup,
   InputLeftElement,
   InputProps,
-  InputRightAddon,
   InputRightElement,
   Text,
-  VStack,
 } from "@chakra-ui/react";
-import { CheckIcon, RepeatIcon } from "@chakra-ui/icons";
+import { RepeatIcon } from "@chakra-ui/icons";
 
 // Equate (BigNumber | undefined) instances with eachother
 function eqBigNumberOptions(
@@ -261,13 +257,11 @@ export const WeiBox: React.FC<WeiBoxProps> = ({
           h="100%"
           children={
             typeof icon === "string" ? (
-              <Center>
-                <Image
-                  src={icon}
-                  boxSize="3rem"
-                  alt="Image left element for WeiBox"
-                />
-              </Center>
+              <Image
+                src={icon}
+                boxSize="3rem"
+                alt="Image left element for WeiBox"
+              />
             ) : (
               icon
             )

--- a/src/views/Staking/index.tsx
+++ b/src/views/Staking/index.tsx
@@ -10,7 +10,7 @@ export interface StakingProps {}
 const StakingErrorWrapper: React.FC = ({ children }) => {
   return (
     <Center
-      minW="31vw"
+      minW={["31vw"]}
       maxW="53.6rem"
       minH="40vh"
       maxH="33.6rem"

--- a/src/views/Staking/layout.tsx
+++ b/src/views/Staking/layout.tsx
@@ -27,6 +27,27 @@ export interface StakingLayoutProps {
   stakingAPY: number;
 }
 
+export const StakingBanner: React.FC<{ tvl: string }> = props => (
+  <Flex px="4.7rem" basis="100%" justifyContent="space-between">
+    <Text fontWeight="bold" color="white" fontSize="2.4rem">
+      Staking
+    </Text>
+    <Center>
+      <Text color="white" fontSize="1.6rem" mr="1.2rem">
+        Funds in the Safety Module
+      </Text>
+      <Text
+        fontSize="2.4rem"
+        fontWeight="bold"
+        bg="linear-gradient(90.53deg, #9BEFD7 0%, #8BF7AB 47.4%, #FFD465 100%);"
+        backgroundClip="text"
+      >
+        ${props.tvl}
+      </Text>
+    </Center>
+  </Flex>
+);
+
 const StakingSubCard: React.FC<{
   isModalTrigger?: boolean;
   onClick: React.MouseEventHandler;


### PR DESCRIPTION
I thought this change was pushed, only to realize this has been on my computer all time. Creating a PR for putting a Staking Banner layout into the layouts file instead of injecting directly into App.tsx