### PR TITLE
Borrow queries

### DIFF
--- a/src/queries/protocolReserveData.ts
+++ b/src/queries/protocolReserveData.ts
@@ -150,7 +150,7 @@ export const useUserReserveData = buildQueryHookWhenParamsDefinedChainAddrs<
       params.library.getSigner()
     );
     return await contract
-      .getUserReserveData(params.account, assetAddress)
+      .getUserReserveData(assetAddress, params.account)
       .then(userReserveData => userReserveDataFromWeb3Result(userReserveData));
   },
   assetAddress => ["user", "reserveData", assetAddress],

--- a/src/queries/protocolReserveData.ts
+++ b/src/queries/protocolReserveData.ts
@@ -85,3 +85,78 @@ export const useProtocolReserveData = buildQueryHookWhenParamsDefinedChainAddrs<
     staleTime: 60 * 5 * 1000,
   }
 );
+
+export interface UserReserveData {
+  // ERC20(LendingPoolReserveData.aTokenAddress).balanceOf(user)
+  currentATokenBalance: BigNumber;
+  // ERC20(reserve.stableDebtTokenAddress).balanceOf(user)
+  currentStableDebt: BigNumber;
+  // ERC20(reserve.variableDebtTokenAddress).balanceOf(user)
+  currentVariableDebt: BigNumber;
+  // The principal stable debt of the user
+  principalStableDebt: BigNumber;
+  // Scaled variable debt of the user
+  scaledVariableDebt: BigNumber;
+  // The stable borrow rate of the user (expressed in ray)
+  stableBorrowRate: FixedNumber;
+  // The interest rate being earned by the user for deposits (expressed in ray)
+  liquidityRate: FixedNumber;
+  // The last time the stable rate was updated for this reserve
+  stableRateLastUpdated: number;
+  // Whether or not this reserve can be used as collateral
+  usageAsCollateralEnabled: boolean;
+}
+
+export function userReserveDataFromWeb3Result({
+  currentATokenBalance,
+  currentStableDebt,
+  currentVariableDebt,
+  principalStableDebt,
+  scaledVariableDebt,
+  stableBorrowRate, // ray
+  liquidityRate, // ray
+  stableRateLastUpdated,
+  usageAsCollateralEnabled,
+}: Web3ProtocolUserReserveDataResult): UserReserveData {
+  return {
+    currentATokenBalance,
+    currentStableDebt,
+    currentVariableDebt,
+    principalStableDebt,
+    scaledVariableDebt,
+    stableBorrowRate: FixedFromRay(stableBorrowRate),
+    liquidityRate: FixedFromRay(liquidityRate),
+    stableRateLastUpdated,
+    usageAsCollateralEnabled,
+  };
+}
+
+type Web3ProtocolUserReserveDataResult = PromisedType<
+  ReturnType<typeof AaveProtocolDataProvider.prototype.getUserReserveData>
+>;
+
+export const useUserReserveData = buildQueryHookWhenParamsDefinedChainAddrs<
+  UserReserveData,
+  [
+    _p1: "user",
+    _p2: "reserveData",
+    assetAddress: string | undefined
+  ],
+  [assetAddress: string]
+>(
+  async (params, assetAddress) => {
+    const contract = AaveProtocolDataProvider__factory.connect(
+      params.chainAddrs.aaveProtocolDataProvider,
+      params.library.getSigner()
+    );
+    return await contract
+      .getUserReserveData(params.account, assetAddress)
+      .then(userReserveData => userReserveDataFromWeb3Result(userReserveData));
+  },
+  assetAddress => ["user", "reserveData", assetAddress],
+  () => undefined,
+  {
+    cacheTime: 60 * 15 * 1000,
+    staleTime: 60 * 5 * 1000,
+  }
+);

--- a/src/views/Dashboard/index.tsx
+++ b/src/views/Dashboard/index.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { DashboardLayout } from "./layout";
-import { useUserDepositAssetBalancesWithReserveInfo } from "../../queries/userAssets";
+import {
+  useUserDepositAssetBalancesWithReserveInfo,
+  useUserVariableDebtTokenBalances
+} from "../../queries/userAssets";
 import { BigNumber } from "ethers";
 import { ReserveTokenDefinition } from "../../queries/allReserveTokens";
 
@@ -12,17 +15,24 @@ export interface AssetData {
 }
 
 export const Dashboard: React.FC<{}> = () => {
+  const borrows = useUserVariableDebtTokenBalances();
+  const borrowedList: AssetData[] = React.useMemo(
+    () => (borrows?.data?.filter(asset => !asset.balance.isZero()) ?? []),
+    [borrows]
+  );
+  console.log('borrows', borrows)
+
   const balances = useUserDepositAssetBalancesWithReserveInfo();
   const depositedList: AssetData[] = React.useMemo(
     () => (balances?.data?.filter(asset => !asset.balance.isZero()) ?? []).map(a => ({ ...a, backingReserve: a.reserve })),
     [balances]
   );
-  
+ 
   return (
     <DashboardLayout
       borrowed={undefined}
       collateral={undefined}
-      borrows={undefined}
+      borrows={borrowedList}
       deposits={depositedList}
       healthFactor={undefined}
     />

--- a/src/views/Dashboard/index.tsx
+++ b/src/views/Dashboard/index.tsx
@@ -6,6 +6,8 @@ import {
 } from "../../queries/userAssets";
 import { BigNumber } from "ethers";
 import { ReserveTokenDefinition } from "../../queries/allReserveTokens";
+import { useAppWeb3 } from "../../hooks/appWeb3";
+import { useUserAccountData } from "../../queries/userAccountData";
 
 export interface AssetData {
   tokenAddress: string;
@@ -15,13 +17,21 @@ export interface AssetData {
 }
 
 export const Dashboard: React.FC<{}> = () => {
+  // Overall borrow information
+  const { account: userAccountAddress } = useAppWeb3();
+  const { data: userAccountData } = useUserAccountData(userAccountAddress ?? undefined);
+  const healthFactor = userAccountData?.healthFactor?.toUnsafeFloat();
+  const collateral = userAccountData?.totalCollateralEth;
+  const borrowed = userAccountData?.totalDebtEth;
+
+  // Borrow list
   const borrows = useUserVariableDebtTokenBalances();
   const borrowedList: AssetData[] = React.useMemo(
     () => (borrows?.data?.filter(asset => !asset.balance.isZero()) ?? []),
     [borrows]
   );
-  console.log('borrows', borrows)
 
+  // Deposit list
   const balances = useUserDepositAssetBalancesWithReserveInfo();
   const depositedList: AssetData[] = React.useMemo(
     () => (balances?.data?.filter(asset => !asset.balance.isZero()) ?? []).map(a => ({ ...a, backingReserve: a.reserve })),
@@ -30,11 +40,11 @@ export const Dashboard: React.FC<{}> = () => {
  
   return (
     <DashboardLayout
-      borrowed={undefined}
-      collateral={undefined}
+      borrowed={borrowed}
+      collateral={collateral}
       borrows={borrowedList}
       deposits={depositedList}
-      healthFactor={undefined}
+      healthFactor={healthFactor}
     />
   );
 };

--- a/src/views/Dashboard/layout.tsx
+++ b/src/views/Dashboard/layout.tsx
@@ -15,6 +15,7 @@ import {
   ModalBody,
 } from "@chakra-ui/react";
 import { useDisclosure } from "@chakra-ui/hooks";
+import { ethers } from "ethers";
 import { fontSizes, spacings } from "../../utils/constants";
 import { CenterProps, HStack } from "@chakra-ui/layout";
 import { isMobileOnly } from "react-device-detect";
@@ -28,9 +29,9 @@ import { formatUnits } from "ethers/lib/utils";
 import { BigNumber, constants } from "ethers";
 
 interface DashboardProps {
-  borrowed: number | undefined;
+  borrowed: BigNumber | undefined;
   borrows: AssetData[] | undefined;
-  collateral: number | undefined;
+  collateral: BigNumber | undefined;
   deposits: AssetData[];
   healthFactor: number | undefined;
 }
@@ -327,13 +328,13 @@ export const DashboardLayout: React.FC<DashboardProps> = ({
             <Box h="7rem" mt="0.5rem">
               <Text>Borrowed</Text>
               <Text fontWeight="bold" textAlign="left" mt="0.5em">
-                {borrowed ?? "-"}
+                {borrowed ? `$ ${ethers.utils.formatEther(borrowed ?? 0)}` : "-"}
               </Text>
             </Box>
             <Box h="7rem" mt="0.5rem" ml="4rem">
               <Text>Collateral</Text>
               <Text fontWeight="bold" textAlign="left" mt="0.5em">
-                {collateral ?? "-"}
+                {collateral ? `$ ${ethers.utils.formatEther(collateral ?? 0)}` : "-"}
               </Text>
             </Box>
             <VStack

--- a/src/views/Dashboard/table.tsx
+++ b/src/views/Dashboard/table.tsx
@@ -84,7 +84,7 @@ export const DashboardTable: React.FC<{
         )) as Renderer<CellProps<AssetData, string>>,
       },
       {
-        Header: mode === DashboardTableType.Borrow ? "APR Type" : "Collateral",
+        Header: mode === DashboardTableType.Borrow ? " " : "Collateral",
         accessor: row => row.tokenAddress,
         Cell: (({ value, row }) => (
           <Box
@@ -93,10 +93,12 @@ export const DashboardTable: React.FC<{
             alignItems="center"
             justifyContent="space-between"
           >
-            <Text fontWeight="bold">
-              {mode === DashboardTableType.Deposit ? "No" : "Variable"}
-            </Text>
-            <CollateralView tokenAddress={value} />
+            {mode === DashboardTableType.Deposit && <>
+              <Text fontWeight="bold">
+                No
+              </Text>
+              <CollateralView tokenAddress={value} />
+            </>}
             <Button bg="secondary.900" _hover={{ bg: "primary.50" }}>
               <ColoredText fontSize="1rem" fontWeight="400">
                 {mode === DashboardTableType.Borrow ? "Borrow" : "Deposit"}

--- a/src/views/common/DepositAPYView.tsx
+++ b/src/views/common/DepositAPYView.tsx
@@ -13,6 +13,6 @@ export const DepositAPYView: React.FC<{ tokenAddress: string }> = ({
       return <>-</>;
     }
     
-    return <PercentageView value={(variableDepositAPY.toUnsafeFloat() * 100)} />;
+    return <PercentageView value={(variableDepositAPY.toUnsafeFloat())} />;
   }, [variableDepositAPY]);
 };


### PR DESCRIPTION
The PR aims to implement the missing borrow queries and use them to hook up the dashboard.

I'm working under the assumption that we want to display the `currentVariableDebt` as opposed to the `scaledVariableDebt` - one seems to be the amount of variable debt tokens the user has, and the other seems to be the amount of the borrowed asset that needs to be repaid (accounting for the borrow rate).

Currently, the health factor displayed for me is super small - I'm not sure if this is because it needs to be formatted in a specific way, or if I am just due to be liquidated. I am leaning towards the former since my collateral is $900 and my total borrow is around $19.