### PR TITLE
Rename `value` to `ratio` on `PercentageView`

### DIFF
--- a/src/views/Markets/index.tsx
+++ b/src/views/Markets/index.tsx
@@ -18,7 +18,7 @@ import {
   useStableBorrowAPR,
   useVariableBorrowAPR,
 } from "../../queries/depositAPY";
-import { PercentageView} from "../common/PercentageView"
+import { PercentageView } from "../common/PercentageView"
 import { TokenIcon } from "../../utils/icons";
 import {
   BasicTableRenderer,
@@ -133,7 +133,7 @@ const DepositAPYView: React.FC<{ tokenAddress: string }> = ({
       return <>-</>;
     }
 
-    return <PercentageView value={query.data.round(4).toUnsafeFloat()} />;
+    return <PercentageView ratio={query.data.round(4).toUnsafeFloat()} />;
   }, [query.data]);
 };
 
@@ -149,7 +149,7 @@ const VariableAPRView: React.FC<{ tokenAddress: string }> = ({
     // HACK: Awaiting rounding bug fix for https://github.com/ethers-io/ethers.js/issues/1629
     return (
       <PercentageView
-        value={query.data
+        ratio={query.data
           .mulUnsafe(FixedNumber.from(1000, query.data.format))
           .floor()
           .divUnsafe(FixedNumber.from(1000, query.data.format))
@@ -171,7 +171,7 @@ const StableAPRView: React.FC<{ tokenAddress: string }> = ({
     // HACK: Awaiting rounding bug fix for https://github.com/ethers-io/ethers.js/issues/1629
     return (
       <PercentageView
-        value={query.data
+        ratio={query.data
           .mulUnsafe(FixedNumber.from(1000, query.data.format))
           .floor()
           .divUnsafe(FixedNumber.from(1000, query.data.format))

--- a/src/views/common/DepositAPYView.tsx
+++ b/src/views/common/DepositAPYView.tsx
@@ -13,6 +13,6 @@ export const DepositAPYView: React.FC<{ tokenAddress: string }> = ({
       return <>-</>;
     }
     
-    return <PercentageView value={(variableDepositAPY.toUnsafeFloat() * 100)} />;
+    return <PercentageView ratio={(variableDepositAPY.toUnsafeFloat() * 100)} />;
   }, [variableDepositAPY]);
 };

--- a/src/views/common/PercentageView.tsx
+++ b/src/views/common/PercentageView.tsx
@@ -4,10 +4,10 @@ import { Text } from "@chakra-ui/layout";
 export const PercentageView: React.FC<{
   lowerIsBetter?: boolean;
   positiveOnly?: boolean;
-  value: number;
+  ratio: number;
 }> = ({
   lowerIsBetter,
-  value,
+  ratio,
   positiveOnly
 }) => {
   if (lowerIsBetter) {
@@ -17,8 +17,8 @@ export const PercentageView: React.FC<{
       throw new Error('PercentageView Mode "positiveOnly" not yet supported');
   }
   return (
-      <Text fontWeight="bold" color={value >= 0 ? "yellow.100" : "red.600"}>
-      % {value * 100}
+      <Text fontWeight="bold" color={ratio >= 0 ? "yellow.100" : "red.600"}>
+      % {ratio * 100}
       </Text>
 );
 };


### PR DESCRIPTION
This is to make it clear that the passed in value should be a ratio, not a percentage, as per [Discord](https://discord.com/channels/816889381737725963/816891254746513439/863219933969645568)