### PR TITLE
Clean up rounding on markets page

### DIFF
--- a/src/views/Markets/index.tsx
+++ b/src/views/Markets/index.tsx
@@ -146,14 +146,9 @@ const VariableAPRView: React.FC<{ tokenAddress: string }> = ({
       return <>-</>;
     }
 
-    // HACK: Awaiting rounding bug fix for https://github.com/ethers-io/ethers.js/issues/1629
     return (
       <PercentageView
-        value={query.data
-          .mulUnsafe(FixedNumber.from(1000, query.data.format))
-          .floor()
-          .divUnsafe(FixedNumber.from(1000, query.data.format))
-          .toUnsafeFloat()}
+        value={query.data.round(4).toUnsafeFloat()}
       />
     );
   }, [query.data]);
@@ -168,14 +163,9 @@ const StableAPRView: React.FC<{ tokenAddress: string }> = ({
       return <>-</>;
     }
 
-    // HACK: Awaiting rounding bug fix for https://github.com/ethers-io/ethers.js/issues/1629
     return (
       <PercentageView
-        value={query.data
-          .mulUnsafe(FixedNumber.from(1000, query.data.format))
-          .floor()
-          .divUnsafe(FixedNumber.from(1000, query.data.format))
-          .toUnsafeFloat()}
+        value={query.data.round(4).toUnsafeFloat()}
       />
     );
   }, [query.data]);


### PR DESCRIPTION
The hacks are no longer necessary as the fix has been merged upstream: https://github.com/ethers-io/ethers.js/issues/1629