### PR TITLE
Treat health factor as not-a-ray (bless)

### DIFF
--- a/src/queries/userAccountData.ts
+++ b/src/queries/userAccountData.ts
@@ -16,7 +16,7 @@ export interface UserAccountData {
   maximumLtvDiscrete: BigNumber; //  Fixed4 e.g. 5781 = 57.81 MaximumLTV
   currentLtv: FixedNumber; // 0 <-> Math.min(maximumLtv, 1), totalDebt / totalCollateral
   usedBorrowingPower: FixedNumber;
-  healthFactor: FixedNumber; //  Ray e.g. 1500403183017056862 = 1.50
+  healthFactor: BigNumber; //  e.g. 2500000000000000000 in wei
 }
 
 export function userAccountDataFromWeb3Result({
@@ -44,7 +44,7 @@ export function userAccountDataFromWeb3Result({
     maximumLtv,
     currentLtv,
     usedBorrowingPower: divIfNotZeroUnsafe(currentLtv, maximumLtv),
-    healthFactor: FixedFromRay(healthFactor),
+    healthFactor,
   };
 }
 

--- a/src/views/Dashboard/index.tsx
+++ b/src/views/Dashboard/index.tsx
@@ -20,7 +20,7 @@ export const Dashboard: React.FC<{}> = () => {
   // Overall borrow information
   const { account: userAccountAddress } = useAppWeb3();
   const { data: userAccountData } = useUserAccountData(userAccountAddress ?? undefined);
-  const healthFactor = userAccountData?.healthFactor?.toUnsafeFloat();
+  const healthFactor = userAccountData?.healthFactor;
   const collateral = userAccountData?.totalCollateralEth;
   const borrowed = userAccountData?.totalDebtEth;
 

--- a/src/views/Dashboard/layout.tsx
+++ b/src/views/Dashboard/layout.tsx
@@ -33,7 +33,7 @@ interface DashboardProps {
   borrows: AssetData[] | undefined;
   collateral: BigNumber | undefined;
   deposits: AssetData[];
-  healthFactor: number | undefined;
+  healthFactor: BigNumber | undefined;
 }
 
 const MODAL_TYPES = {
@@ -355,7 +355,7 @@ export const DashboardLayout: React.FC<DashboardProps> = ({
                 />
               </HStack>
               <Text fontWeight="bold" textAlign="left" mt="0.5em">
-                {healthFactor ?? "-"}
+                {healthFactor ? ethers.utils.formatEther(healthFactor).toLocaleString() : "-"}
               </Text>
             </VStack>
           </Box>

--- a/src/views/common/DepositDash.tsx
+++ b/src/views/common/DepositDash.tsx
@@ -1,6 +1,7 @@
 import { Box, HStack, Stack, Text, VStack, useMediaQuery, Flex } from "@chakra-ui/react";
 import { formatEther } from "ethers/lib/utils";
 import React from "react";
+import { ethers } from "ethers";
 import ColoredText from "../../components/ColoredText";
 import { useAppWeb3 } from "../../hooks/appWeb3";
 import { ReserveTokenDefinition } from "../../queries/allReserveTokens";
@@ -88,7 +89,7 @@ export const DepositDash: React.FC<DepositDashProps> = ({
 			  <Text fontSize={{ base: fontSizes.sm, md: fontSizes.md }} >Health factor</Text>
 			  <ModalIcon position="relative" top="0" right="0" onOpen={() => {}} />
 		  </HStack>
-          <ColoredText fontSize={{ base: fontSizes.md, md: fontSizes.lg  }}>{healthFactor?.toUnsafeFloat().toLocaleString() ?? "-"}</ColoredText>
+          <ColoredText fontSize={{ base: fontSizes.md, md: fontSizes.lg  }}>{healthFactor ? ethers.utils.formatEther(healthFactor).toLocaleString() : "-"}</ColoredText>
         </Flex>
       </Flex>
       <Flex 

--- a/src/views/common/WithdrawDash.tsx
+++ b/src/views/common/WithdrawDash.tsx
@@ -21,6 +21,7 @@ import {
 } from "@chakra-ui/react";
 import { formatEther } from "ethers/lib/utils";
 import React from "react";
+import { ethers } from "ethers";
 import ColoredText from "../../components/ColoredText";
 import { useAppWeb3 } from "../../hooks/appWeb3";
 import { ReserveTokenDefinition } from "../../queries/allReserveTokens";
@@ -145,7 +146,7 @@ export const WithdrawDash: React.FC<WithdrawDashProps> = ({
 						<Text fontSize={{ base: fontSizes.sm, md: fontSizes.md }}  >Health factor</Text>
 					</HStack>
 					<HStack pr={{ base: "0rem", md: "1rem" }} textAlign="center" w="100%">
-						<ColoredText minW={{base:'30px',md:"100%"}}> {healthFactor?.toUnsafeFloat().toLocaleString() ?? "-"}</ColoredText>
+						<ColoredText minW={{base:'30px',md:"100%"}}> {healthFactor ? ethers.utils.formatEther(healthFactor).toLocaleString() : "-"}</ColoredText>
 						<ModalIcon position="relative" top="0" right="0" onOpen={() => { }} />
 					</HStack>
 				</Flex>

--- a/src/views/common/Wizard.tsx
+++ b/src/views/common/Wizard.tsx
@@ -64,9 +64,7 @@ export const WizardOverviewWrapper: React.FC<{
             overflow="hidden"
             overflowWrap="normal"
           >
-            {currentHealthFactor
-              ?.toUnsafeFloat()
-              .toLocaleString(undefined, { notation: "scientific" }) ?? "-"}
+            {currentHealthFactor ? formatEther(currentHealthFactor) : "-"}
           </ColoredText>
         </HStack>
         {/* Calculating this is hard - do it later */}


### PR DESCRIPTION
Health factor was incorrectly assumed to be a ray, so this PR reverts that behavior and updates all references to the health factor so that the site still builds - note that this does not mean that the format of the health factor is correct in all places, I only looked at the places that prevented the site from building and updated those accordingly.