### PR TITLE
Change terminology from commit to sign on tx's

### DIFF
--- a/src/mutations/approval.ts
+++ b/src/mutations/approval.ts
@@ -60,7 +60,7 @@ export const useApprovalMutation = ({
           const approvalReset = tokenContract.approve(spender, constants.Zero);
           const approvalResetConfirmation = await usingProgressNotification(
             "Awaiting approval reset",
-            "Some ERC20-like tokens require setting your allowance to 0 before changing it. Please commit the transaction resetting approval to 0.",
+            "Some ERC20-like tokens require setting your allowance to 0 before changing it. Please sign the transaction resetting approval to 0.",
             "warning",
             approvalReset
           );
@@ -75,7 +75,7 @@ export const useApprovalMutation = ({
         const approval = tokenContract.approve(spender, amount);
         const approvalConfirmation = await usingProgressNotification(
           "Awaiting spend approval",
-          "Please commit the transaction for ERC20 approval.",
+          "Please sign the transaction for ERC20 approval.",
           "info",
           approval
         );

--- a/src/mutations/claim.ts
+++ b/src/mutations/claim.ts
@@ -73,7 +73,7 @@ export const useClaimMutation = ({
       );
       const claimConfirmation = await usingProgressNotification(
         "Awaiting claim transaction approval",
-        "Please commit the claim transaction with your wallet.",
+        "Please sign the claim transaction with your wallet.",
         "info",
         claimRequest
       );

--- a/src/mutations/cooldown.ts
+++ b/src/mutations/cooldown.ts
@@ -66,7 +66,7 @@ export const useCooldownMutation = ({
       const cooldownRequest = stakingContract.cooldown();
       const cooldownConfirmation = await usingProgressNotification(
         "Awaiting cooldown transaction approval",
-        "Please commit the cooldown transaction with your wallet.",
+        "Please sign the cooldown transaction with your wallet.",
         "info",
         cooldownRequest
       );

--- a/src/mutations/deposit.ts
+++ b/src/mutations/deposit.ts
@@ -79,7 +79,7 @@ export const useDepositMutation = ({
       const deposit = lendingContract.deposit(asset, amount, account, 0);
       const depositConfirmation = await usingProgressNotification(
         "Awaiting deposit approval",
-        "Please commit the transaction for deposit.",
+        "Please sign the transaction for deposit.",
         "info",
         deposit
       );

--- a/src/mutations/redeem.ts
+++ b/src/mutations/redeem.ts
@@ -71,7 +71,7 @@ export const useRedeemMutation = ({
       const redeemRequest = stakingContract.redeem(args.recipient, args.amount);
       const redeemConfirmation = await usingProgressNotification(
         "Awaiting redeem transaction approval",
-        "Please commit the redeem transaction with your wallet.",
+        "Please sign the redeem transaction with your wallet.",
         "info",
         redeemRequest
       );

--- a/src/mutations/stake.ts
+++ b/src/mutations/stake.ts
@@ -82,7 +82,7 @@ export const useStakeMutation = ({
           );
           const approvalResetConfirmation = await usingProgressNotification(
             "Awaiting approval reset",
-            "MiniMe tokens require setting your allowance to 0 before changing it. Please commit the transaction resetting MiniMe approval to 0 to patch inconsistent state",
+            "MiniMe tokens require setting your allowance to 0 before changing it. Please sign the transaction resetting MiniMe approval to 0 to patch inconsistent state",
             "warning",
             approvalReset
           );

--- a/src/mutations/withdraw.ts
+++ b/src/mutations/withdraw.ts
@@ -79,7 +79,7 @@ export const useWithdrawMutation = ({
       const withdraw = lendingContract.withdraw(asset, amount, account);
       const withdrawConfirmation = await usingProgressNotification(
         "Awaiting withdraw approval",
-        "Please commit the transaction for withdrawal.",
+        "Please sign the transaction for withdrawal.",
         "info",
         withdraw
       );


### PR DESCRIPTION
This is a small change, instead of prompting the user to "commit" the transaction, we prompt them to sign it, as that is more familiar terminology for most users.

Note that if this is not the direction we want to go in, we should change the mutation in #39 