### PR TITLE
Withdraw Dash support for Native token

### DIFF
--- a/src/mutations/deposit.ts
+++ b/src/mutations/deposit.ts
@@ -16,7 +16,10 @@ import { useUserAccountData } from "../queries/userAccountData";
 import { useLendingReserveData } from "../queries/lendingReserveData";
 import { getChainAddresses } from "../utils/chainAddresses";
 import { NATIVE_TOKEN } from "../queries/allReserveTokens";
-import { useWrappedNativeAddress } from "../queries/wrappedNativeAddress";
+import {
+  useWrappedNativeAddress,
+  useWrappedNativeDefinition,
+} from "../queries/wrappedNativeAddress";
 import { useUserReserveData } from "../queries/protocolReserveData";
 
 export interface UseDepositMutationProps {
@@ -46,8 +49,7 @@ export const useDepositMutation = ({
 }: UseDepositMutationProps): UseDepositMutationDto => {
   const queryClient = useQueryClient();
   const { chainId, account, library } = useAppWeb3();
-  // TODO: Switch to use `useWrappedNativeDefinition` when PR is in
-  const { data: wrappedNativeTokenAddress } = useWrappedNativeAddress();
+  const { data: wrappedNativeToken } = useWrappedNativeDefinition();
 
   const userAccountDataQueryKey = useUserAccountData.buildKey(
     chainId ?? undefined,
@@ -57,12 +59,12 @@ export const useDepositMutation = ({
   const assetBalanceQueryKey = useUserAssetBalance.buildKey(
     chainId ?? undefined,
     account ?? undefined,
-    asset !== NATIVE_TOKEN ? asset : wrappedNativeTokenAddress
+    asset !== NATIVE_TOKEN ? asset : wrappedNativeToken?.tokenAddress
   );
   const allowanceQueryKey = useUserAssetAllowance.buildKey(
     chainId ?? undefined,
     account ?? undefined,
-    asset !== NATIVE_TOKEN ? asset : wrappedNativeTokenAddress,
+    asset !== NATIVE_TOKEN ? asset : wrappedNativeToken?.tokenAddress,
     spender ?? undefined
   );
   const depositedQueryKey = [...allowanceQueryKey, "deposit"] as const;

--- a/src/views/Withdraw/WithdrawDash.tsx
+++ b/src/views/Withdraw/WithdrawDash.tsx
@@ -15,7 +15,11 @@ import { bigNumberToString } from "../../utils/fixedPoint";
 import React from "react";
 import ColoredText from "../../components/ColoredText";
 import { useAppWeb3 } from "../../hooks/appWeb3";
-import { ReserveTokenDefinition } from "../../queries/allReserveTokens";
+import {
+  NATIVE_TOKEN,
+  ReserveOrNativeTokenDefinition,
+  ReserveTokenDefinition,
+} from "../../queries/allReserveTokens";
 import { useAssetPriceInDai } from "../../queries/assetPriceInDai";
 import { useAllReserveTokensWithData } from "../../queries/lendingReserveData";
 // import { useProtocolReserveConfiguration } from "../../queries/protocolAssetConfiguration";
@@ -26,21 +30,27 @@ import { useUserReserveAssetBalancesDaiWei } from "../../queries/userAssets";
 import { useUserAssetBalance } from "../../queries/userAssets";
 import { fontSizes, spacings, assetColor } from "../../utils/constants";
 import { TokenIcon } from "../../utils/icons";
+import { useWrappedNativeDefinition } from "../../queries/wrappedNativeAddress";
 
 type WithdrawDashProps = {
-  token: ReserveTokenDefinition;
+  token: ReserveOrNativeTokenDefinition;
 };
 
 export const WithdrawDash: React.FC<WithdrawDashProps> = ({ token }) => {
   const { account: userAccountAddress } = useAppWeb3();
   const { data: reserves } = useAllReserveTokensWithData();
+  const { data: wNative } = useWrappedNativeDefinition();
+  const asset = token.tokenAddress === NATIVE_TOKEN ? wNative : token;
+  const tokenAddresses = reserves?.map(asset => {
+    return asset.tokenAddress;
+  });
   const reserve = React.useMemo(
     () =>
-      reserves?.find(reserve => reserve.tokenAddress === token.tokenAddress) ??
+      reserves?.find(reserve => reserve.tokenAddress === asset?.tokenAddress) ??
       reserves?.find(
         reserve =>
           reserve.tokenAddress.toLowerCase() ===
-          token.tokenAddress.toLowerCase()
+          asset?.tokenAddress.toLowerCase()
       ),
     [reserves, token.tokenAddress]
   );
@@ -260,6 +270,7 @@ export const WithdrawDash: React.FC<WithdrawDashProps> = ({ token }) => {
               >
                 {allReservesData?.map((token, index) => (
                   <Box
+                    key={"box" + index}
                     bg={assetColor[token.symbol]}
                     w="100%"
                     h="100%"
@@ -278,6 +289,7 @@ export const WithdrawDash: React.FC<WithdrawDashProps> = ({ token }) => {
                   {allReservesData?.map((token, index) =>
                     collateralComposition[index] !== null ? (
                       <Flex
+                        key={"flex" + index}
                         id={index + token.symbol}
                         alignItems="center"
                         justifyContent="space-between"
@@ -296,9 +308,7 @@ export const WithdrawDash: React.FC<WithdrawDashProps> = ({ token }) => {
                         </Text>
                         <Text ml="1em"> {collateralData[index] + "%"}</Text>
                       </Flex>
-                    ) : (
-                      <Text></Text>
-                    )
+                    ) : null
                   )}
                 </VStack>
               </PopoverBody>


### PR DESCRIPTION
Withdraw Detail now does not throw when using a NATIVE token, however, the allowances for the NATIVE token when repaying are not checking as intended yet
Simple moved into wrappedTokenDefinition as commented in the deposit mutation