### PR TITLE
Repay increase limit

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,7 +14,7 @@ export const spacings = {
 };
 
 export const MIN_SAFE_HEALTH_FACTOR = BigNumber.from(1200);
-export const MINIMUM_NATIVE_RESERVE = constants.WeiPerEther.div(10);
+export const MINIMUM_NATIVE_RESERVE = constants.WeiPerEther.div(50);
 
 export const assetColor: { [key: string]: string } = {
   USDC: theme.colors.blue[400],

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -114,9 +114,8 @@ export function bnMaxish(a: BigNumber, b: BigNumberish): BigNumber {
 }
 
 // Take the greater of A and B, preferring A if both are equal; Requires that both are BigNumber
-export function bnMax(a: BigNumber, b: BigNumberish): BigNumber {
-  const bbn = BigNumber.isBigNumber(b) ? b : BigNumber.from(b);
-  return a.gte(bbn) ? a : bbn;
+export function bnMax(a: BigNumber, b: BigNumber): BigNumber {
+  return a.gte(b) ? a : b;
 }
 
 // Take the greater of A and B, preferring A if both are equal

--- a/src/views/Repay/RepayDetail.tsx
+++ b/src/views/Repay/RepayDetail.tsx
@@ -97,10 +97,12 @@ const InitialComp: React.FC<{
     }
 
     // availableToRepay = min(debt, balance)
-    // 10% gap to make sure the interest accrued during the time between fetching and repaying
+    // 5% gap to make sure the interest accrued during the time between fetching and repaying
     // is accounted for ->  (difference gets minted as agToken)
-    return userBalance.gt(debtForAsset.mul(11).div(10))
-      ? debtForAsset.mul(10).div(9).add(MINIMUM_NATIVE_RESERVE)
+    return userBalance.gt(
+      debtForAsset.mul(21).div(20).add(MINIMUM_NATIVE_RESERVE)
+    )
+      ? debtForAsset.mul(21).div(20)
       : userBalance;
   }, [debtForAsset, userBalance]);
 

--- a/src/views/Repay/RepayDetail.tsx
+++ b/src/views/Repay/RepayDetail.tsx
@@ -5,15 +5,13 @@ import { useHistory, useRouteMatch } from "react-router-dom";
 import { RepayDash } from "./RepayDash";
 import { DashOverviewIntro } from "../common/DashOverview";
 import {
-  isReserveTokenDefinition,
   NATIVE_TOKEN,
   ReserveOrNativeTokenDefinition,
-  ReserveTokenDefinition,
   useTokenDefinitionBySymbol,
 } from "../../queries/allReserveTokens";
 import { Box, Center } from "@chakra-ui/react";
 import ColoredText from "../../components/ColoredText";
-import { BigNumber } from "ethers";
+import { BigNumber, constants } from "ethers";
 import { OneTaggedPropertyOf, PossibleTags } from "../../utils/types";
 import {
   useUserAssetBalance,
@@ -29,6 +27,7 @@ import { ControllerItem } from "../../components/ControllerItem";
 import { StepperBar, WizardOverviewWrapper } from "../common/Wizard";
 import { useWrappedNativeDefinition } from "../../queries/wrappedNativeAddress";
 import { MINIMUM_NATIVE_RESERVE } from "../../utils/constants";
+import { bnMax, bnMin } from "../../utils/helpers";
 
 interface InitialState {
   token: Readonly<ReserveOrNativeTokenDefinition>;
@@ -84,6 +83,7 @@ const InitialComp: React.FC<{
 }> = ({ state, dispatch }) => {
   const [amount, setAmount] = React.useState<BigNumber>();
   const { data: wNative } = useWrappedNativeDefinition();
+  const paymentAssetIsNative = state.token.tokenAddress === NATIVE_TOKEN;
   const asset =
     state.token.tokenAddress === NATIVE_TOKEN ? wNative : state.token;
 
@@ -91,20 +91,28 @@ const InitialComp: React.FC<{
   const { data: debtForAsset } = useUserVariableDebtForAsset(
     asset?.tokenAddress
   );
-  const availableToRepay = React.useMemo(() => {
-    if (!userBalance || !debtForAsset) {
-      return BigNumber.from(0);
+  const availableToRepay: BigNumber | undefined = React.useMemo(() => {
+    // If either are null, we can't provide anything useful
+    // Propagating undefined lets the DashOverviewIntro know we're still loading the value
+    if (userBalance === undefined || debtForAsset === undefined) {
+      return undefined;
     }
-
-    // availableToRepay = min(debt, balance)
-    // 5% gap to make sure the interest accrued during the time between fetching and repaying
-    // is accounted for ->  (difference gets minted as agToken)
-    return userBalance.gt(
-      debtForAsset.mul(21).div(20).add(MINIMUM_NATIVE_RESERVE)
-    )
-      ? debtForAsset.mul(21).div(20)
+    // Start with the user's debt
+    let maxRepaymentAmount = debtForAsset;
+    // 5% extra to ensure sufficient coverage for interest accrued during the time between fetching and repaying
+    // (difference gets minted as agToken)
+    // TODO: Change this to a time-based multiplier of APR, for example, 10 minutes worth of interest
+    maxRepaymentAmount = maxRepaymentAmount.mul(21).div(20);
+    // The user can only pay as much as their actual balance
+    // If the payment asset is native, ensure a surplus remaining of at least the minimum native balance
+    const usefulBalance = paymentAssetIsNative
+      ? userBalance.sub(MINIMUM_NATIVE_RESERVE)
       : userBalance;
-  }, [debtForAsset, userBalance]);
+    maxRepaymentAmount = bnMin(maxRepaymentAmount, usefulBalance);
+    // Max repayment amount cannot be negative
+    maxRepaymentAmount = bnMax(maxRepaymentAmount, constants.Zero);
+    return maxRepaymentAmount;
+  }, [debtForAsset, userBalance, paymentAssetIsNative]);
 
   const onSubmit = React.useCallback(
     amountToRepay =>

--- a/src/views/common/DashOverview.tsx
+++ b/src/views/common/DashOverview.tsx
@@ -74,7 +74,7 @@ export const DashOverviewIntro: React.FC<{
         healthFactor={newHealthFactor}
         mode={mode}
         balance={
-          // If NATIVE don't allow to deposit the full balance in a wallet! LeInfoWeiBoxe 0.1
+          // If NATIVE don't allow to deposit the full balance in a wallet! Leave 0.1
           asset.tokenAddress === NATIVE_TOKEN &&
           (mode === "deposit" || mode === "repay")
             ? limitAmount?.sub(MINIMUM_NATIVE_RESERVE)

--- a/src/views/common/DashOverview.tsx
+++ b/src/views/common/DashOverview.tsx
@@ -52,12 +52,13 @@ export const DashOverviewIntro: React.FC<{
   );
 
   const limitAmount =
-    balance && maxAmount?.lt(balance)
+    (mode === "withdraw" || mode === "borrow") &&
+    balance &&
+    maxAmount?.lt(balance)
       ? maxAmount.gt(constants.Zero)
         ? maxAmount
         : constants.Zero
       : balance;
-
   return (
     <VStack w={{ base: "90%", sm: "75%", md: "60%", lg: "50%" }} spacing="0">
       <ColoredText fontSize="1.8rem" textTransform="capitalize" pb="1rem">
@@ -73,7 +74,7 @@ export const DashOverviewIntro: React.FC<{
         healthFactor={newHealthFactor}
         mode={mode}
         balance={
-          // If NATIVE don't allow to deposit the full balance in a wallet! Leave 0.1
+          // If NATIVE don't allow to deposit the full balance in a wallet! LeInfoWeiBoxe 0.1
           asset.tokenAddress === NATIVE_TOKEN &&
           (mode === "deposit" || mode === "repay")
             ? limitAmount?.sub(MINIMUM_NATIVE_RESERVE)


### PR DESCRIPTION
 Fix bug where repayment MAX would not cover for full amount of the debt interest 10% gap to make sure the interest accrued during the time between fetching and repaying is accounted for ->  (difference gets minted as agToken)