### PR TITLE
Allow Stable Borrowing

### DIFF
--- a/src/components/ControllerItem/index.tsx
+++ b/src/components/ControllerItem/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactChild } from "react";
 import { Center, VStack, Text, Button } from "@chakra-ui/react";
 import { LINEAR_GRADIENT_BG, fontSizes } from "../../utils/constants";
 
@@ -9,6 +9,7 @@ export const ControllerItem: React.FC<{
   stepNumber: number;
   onActionClick: () => void;
   totalSteps: number;
+  childComponent?: ReactChild | undefined;
 }> = ({
   stepDesc,
   stepName,
@@ -16,6 +17,7 @@ export const ControllerItem: React.FC<{
   onActionClick,
   totalSteps,
   stepNumber,
+  childComponent,
 }) => {
   return (
     <Center w="100%" justifyContent="space-between" p="1.2rem">
@@ -28,7 +30,7 @@ export const ControllerItem: React.FC<{
         </Text>
         {stepDesc && (
           <Text fontSize={{ base: fontSizes.sm, md: fontSizes.md }}>
-            {stepDesc}
+            {childComponent ? childComponent : stepDesc}
           </Text>
         )}
       </VStack>

--- a/src/mutations/borrow.ts
+++ b/src/mutations/borrow.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient, UseMutationResult } from "react-query";
 import { AgaveLendingABI__factory, WETHGateway__factory } from "../contracts";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BigNumber, BigNumberish } from "@ethersproject/bignumber";
 import {
   useUserAssetAllowance,
   useUserAssetBalance,
@@ -26,6 +26,7 @@ export interface UseBorrowMutationProps {
   asset: string | NATIVE_TOKEN | undefined;
   onBehalfOf: string | undefined;
   amount: BigNumber | undefined;
+  interestRateMode: BigNumber | undefined;
 }
 
 export interface UseBorrowMutationDto {
@@ -46,6 +47,7 @@ export const useBorrowMutation = ({
   asset,
   onBehalfOf,
   amount,
+  interestRateMode,
 }: UseBorrowMutationProps): UseBorrowMutationDto => {
   const queryClient = useQueryClient();
   const { chainId, account, library } = useAppWeb3();
@@ -90,12 +92,16 @@ export const useBorrowMutation = ({
       if (!chainAddresses) {
         return undefined;
       }
-      if (!asset || !onBehalfOf || !amount) {
+      if (!asset || !onBehalfOf || !amount || !interestRateMode) {
         return undefined;
       }
-
+      if (
+        !interestRateMode.eq(BigNumber.from(1)) &&
+        !interestRateMode.eq(BigNumber.from(2))
+      ) {
+        return undefined;
+      }
       let borrow;
-      const interestRateMode = 2;
       const referralCode = 0;
       if (asset === NATIVE_TOKEN) {
         const gatewayContract = WETHGateway__factory.connect(

--- a/src/views/Borrow/BorrowDetail.tsx
+++ b/src/views/Borrow/BorrowDetail.tsx
@@ -10,7 +10,8 @@ import {
   ReserveOrNativeTokenDefinition,
   useTokenDefinitionBySymbol,
 } from "../../queries/allReserveTokens";
-import { Box, Center, Text } from "@chakra-ui/react";
+import { useProtocolReserveConfiguration } from "../../queries/protocolAssetConfiguration";
+import { Box, Center, Text, Switch, Checkbox } from "@chakra-ui/react";
 import ColoredText from "../../components/ColoredText";
 import { BigNumber } from "ethers";
 import { OneTaggedPropertyOf, PossibleTags } from "../../utils/types";
@@ -36,6 +37,7 @@ import {
 import { useLendingReserveData } from "../../queries/lendingReserveData";
 import { bigNumberToString } from "../../utils/fixedPoint";
 import { useDecimalCountForToken } from "../../queries/decimalsForToken";
+import { fontSizes } from "../../utils/constants";
 
 interface InitialState {
   token: Readonly<ReserveOrNativeTokenDefinition>;
@@ -45,7 +47,11 @@ interface AmountSelectedState extends InitialState {
   amountToBorrow: BigNumber;
 }
 
-interface BorrowTXState extends AmountSelectedState {
+interface RateSelectedState extends AmountSelectedState {
+  interestRateMode: number;
+}
+
+interface BorrowTXState extends RateSelectedState {
   // approvalTXHash: string | undefined;
 }
 
@@ -56,6 +62,7 @@ interface BorrowedTXState extends BorrowTXState {
 type BorrowState = OneTaggedPropertyOf<{
   init: InitialState;
   amountSelected: AmountSelectedState;
+  rateSelected: RateSelectedState;
   borrowTx: BorrowTXState;
   borrowedTx: BorrowedTXState;
 }>;
@@ -73,13 +80,15 @@ function createState<SelectedState extends PossibleTags<BorrowState>>(
 // THIS BorrowState IS ALL WRONG AND NEEDS FIXING WHEN THE QUERIES ARE DONE
 const stateNames: Record<PossibleTags<BorrowState>, string> = {
   init: "Token",
-  amountSelected: "Delegate",
+  amountSelected: "Mode",
+  rateSelected: "Delegate",
   borrowTx: "Borrow",
   borrowedTx: "Borrowed",
 };
 
 const visibleStateNames: ReadonlyArray<PossibleTags<BorrowState>> = [
   "amountSelected",
+  "rateSelected",
   "borrowTx",
   "borrowedTx",
 ] as const;
@@ -127,9 +136,12 @@ const InitialComp: React.FC<{
       : userAssetMaxAvailable;
   const onSubmit = React.useCallback(
     amountToBorrow => {
-      isReserveTokenDefinition(state.token)
-        ? dispatch(createState("borrowTx", { amountToBorrow, ...state }))
-        : dispatch(createState("amountSelected", { amountToBorrow, ...state }));
+      dispatch(
+        createState("amountSelected", {
+          amountToBorrow,
+          ...state,
+        })
+      );
     },
     [state, dispatch]
   );
@@ -147,6 +159,74 @@ const InitialComp: React.FC<{
 
 const AmountSelectedComp: React.FC<{
   state: AmountSelectedState;
+  dispatch: (nextState: BorrowState) => void;
+}> = ({ state, dispatch }) => {
+  const { data: wNative } = useWrappedNativeDefinition();
+  const asset =
+    state.token.tokenAddress === NATIVE_TOKEN ? wNative : state.token;
+  const reserveData = useProtocolReserveConfiguration(
+    asset?.tokenAddress
+  )?.data;
+  const { stableBorrowRateEnabled } = reserveData ?? {};
+  const [interestRateMode, setInterestRateMode] = React.useState<number>(stableBorrowRateEnabled ? 1 : 2);
+
+  const onSubmit = React.useCallback(() => {
+    isReserveTokenDefinition(state.token)
+      ? dispatch(createState("borrowTx", { interestRateMode, ...state }))
+      : dispatch(createState("rateSelected", { interestRateMode, ...state }));
+  }, [state, dispatch, interestRateMode]);
+  const currentStep: PossibleTags<BorrowState> = "amountSelected";
+
+  const stepperBar = React.useMemo(
+    () => (
+      <StepperBar
+        states={visibleStateNames}
+        currentState={currentStep}
+        stateNames={stateNames}
+      />
+    ),
+    [currentStep]
+  );
+  const borrowModeCheckbox = React.useMemo(
+    () => (
+      <Text fontSize={{ base: fontSizes.sm, md: fontSizes.md }}>
+        <Checkbox
+          size="lg"
+          colorScheme="orange"
+          onChange={event => setInterestRateMode(event.target.checked ? 1 : 2)}
+          defaultChecked={interestRateMode === 1}
+          isDisabled={!stableBorrowRateEnabled}
+        >
+          Variable Borrowing
+        </Checkbox>
+      </Text>
+    ),
+    [currentStep]
+  );
+  return (
+    <WizardOverviewWrapper
+      title={BorrowTitle}
+      amount={state.amountToBorrow}
+      asset={state.token}
+      collateral={true}
+      increase={true}
+    >
+      {stepperBar}
+      <ControllerItem
+        stepNumber={1}
+        stepName="Rate Mode"
+        stepDesc="Submit to delegate approval to WETHGateway"
+        actionName="Approve"
+        onActionClick={onSubmit}
+        totalSteps={visibleStateNames.length}
+        childComponent={borrowModeCheckbox}
+      />
+    </WizardOverviewWrapper>
+  );
+};
+
+const RateSelectedComp: React.FC<{
+  state: RateSelectedState;
   dispatch: (nextState: BorrowState) => void;
 }> = ({ state, dispatch }) => {
   const chainAddresses = useChainAddresses();
@@ -169,7 +249,7 @@ const AmountSelectedComp: React.FC<{
       // TODO: Switch to an error-display state that returns to init
       .catch(e => dispatch(createState("init", state)));
   }, [state, dispatch, mutateAsync]);
-  const currentStep: PossibleTags<BorrowState> = "amountSelected";
+  const currentStep: PossibleTags<BorrowState> = "rateSelected";
   const stepperBar = React.useMemo(
     () => (
       <StepperBar
@@ -190,7 +270,7 @@ const AmountSelectedComp: React.FC<{
     >
       {stepperBar}
       <ControllerItem
-        stepNumber={1}
+        stepNumber={2}
         stepName="Delegate"
         stepDesc="Submit to delegate approval to WETHGateway"
         actionName="Approve"
@@ -250,7 +330,7 @@ const BorrowTxComp: React.FC<{
     >
       {stepperBar}
       <ControllerItem
-        stepNumber={1}
+        stepNumber={3}
         stepName="Borrow"
         stepDesc="Please submit to borrow"
         actionName="Borrow"
@@ -288,7 +368,7 @@ const BorrowedTxComp: React.FC<{
     >
       {stepperBar}
       <ControllerItem
-        stepNumber={2}
+        stepNumber={4}
         stepName="Borrowed"
         stepDesc={`Borrow of ${bigNumberToString(
           state.amountToBorrow,
@@ -313,6 +393,10 @@ const BorrowStateMachine: React.FC<{
     case "amountSelected":
       return (
         <AmountSelectedComp state={state.amountSelected} dispatch={setState} />
+      );
+    case "rateSelected":
+      return (
+        <RateSelectedComp state={state.rateSelected} dispatch={setState} />
       );
     case "borrowTx":
       return <BorrowTxComp state={state.borrowTx} dispatch={setState} />;

--- a/src/views/Borrow/BorrowDetail.tsx
+++ b/src/views/Borrow/BorrowDetail.tsx
@@ -48,7 +48,7 @@ interface AmountSelectedState extends InitialState {
 }
 
 interface RateSelectedState extends AmountSelectedState {
-  interestRateMode: number;
+  interestRateMode: BigNumber;
 }
 
 interface BorrowTXState extends RateSelectedState {
@@ -168,12 +168,24 @@ const AmountSelectedComp: React.FC<{
     asset?.tokenAddress
   )?.data;
   const { stableBorrowRateEnabled } = reserveData ?? {};
-  const [interestRateMode, setInterestRateMode] = React.useState<number>(stableBorrowRateEnabled ? 1 : 2);
+  const [interestRateMode, setInterestRateMode] = React.useState<number>(
+    stableBorrowRateEnabled ? 1 : 2
+  );
 
   const onSubmit = React.useCallback(() => {
     isReserveTokenDefinition(state.token)
-      ? dispatch(createState("borrowTx", { interestRateMode, ...state }))
-      : dispatch(createState("rateSelected", { interestRateMode, ...state }));
+      ? dispatch(
+          createState("borrowTx", {
+            interestRateMode: BigNumber.from(interestRateMode),
+            ...state,
+          })
+        )
+      : dispatch(
+          createState("rateSelected", {
+            interestRateMode: BigNumber.from(interestRateMode),
+            ...state,
+          })
+        );
   }, [state, dispatch, interestRateMode]);
   const currentStep: PossibleTags<BorrowState> = "amountSelected";
 
@@ -297,6 +309,7 @@ const BorrowTxComp: React.FC<{
       asset: state.token.tokenAddress,
       amount: state.amountToBorrow,
       onBehalfOf: account ?? undefined,
+      interestRateMode: state.interestRateMode,
     }),
     [state, account]
   );


### PR DESCRIPTION
## THIS PR NEEDS THE MERGE OF PR #142

A new step is added to the borrow wizard to ask the user if he wants to use variable borrow rate or stable with a checkbox. Some assets do not accept stable borrow rates, for those assets the checkbox is disabled.
 
<img width="489" alt="image" src="https://user-images.githubusercontent.com/28935185/183469596-8e4e0c10-5df5-4cd6-94f6-dda1935f2d98.png">

| Unchecked | Checked | Disabled |
| - | - | - |
| <img width="138" alt="image" src="https://user-images.githubusercontent.com/28935185/183469723-789092f1-c306-43f6-964e-d5b2cd652e4f.png"> | <img width="138" alt="image" src="https://user-images.githubusercontent.com/28935185/183469762-e7d51e8f-8db9-4e75-9701-d04aa77dabcc.png"> | <img width="138" alt="image" src="https://user-images.githubusercontent.com/28935185/183469802-c026c19d-a8e8-4d09-befe-747af6eb3aeb.png"> |